### PR TITLE
Bug Fix for removing listeners

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -505,6 +505,7 @@
                         for (i = 0; i < len; i++) {
                             remove(element, type, target.events[type][i], Boolean(useCapture));
                         }
+                        return;
                     } else {
                         for (i = 0; i < len; i++) {
                             if (target.events[type][i] === listener) {
@@ -532,9 +533,9 @@
                 }
 
                 if (!target.typeCount) {
-                    targets.splice(elementIndex);
-                    elements.splice(elementIndex);
-                    attachedListeners.splice(elementIndex);
+                    targets.splice(elementIndex, 1);
+                    elements.splice(elementIndex, 1);
+                    attachedListeners.splice(elementIndex, 1);
                 }
             }
 
@@ -5183,7 +5184,7 @@
          = (object) @interact
         \*/
         unset: function () {
-            events.remove(this, 'all');
+            events.remove(this._element, 'all');
 
             if (!isString(this.selector)) {
                 events.remove(this, 'all');


### PR DESCRIPTION
Three bug fixes for cleaning up listeners:
1. Call 'var myInteractable = interact(myElem)' --> the Interactable constructor will call 'events.add(this._element, ...)'
    The unset method -- 'myInteractable.unset()' -- should be calling 'events.remove(this._element, 'all')' to remove those event handlers
2.  The 'remove' method should only remove 1 element when calling splice instead of all elements after the specified index.
3.  On top of #2, the 'remove' method should return after looping through the 'all' listener condition so that the arrays are only spliced one time instead of twice (once after removing the specific handler and once after the 'all' loop finishes)
